### PR TITLE
Link Object3d to external WorldTransform

### DIFF
--- a/project/engine/3D/Object3d.cpp
+++ b/project/engine/3D/Object3d.cpp
@@ -16,8 +16,8 @@ void Object3d::Initialize(Object3dCommon* object3dCommon, WorldTransform* worldT
 	assert(object3dCommon != nullptr);
 	assert(worldTransform != nullptr);
 
-	this->object3dCommon_ = object3dCommon;
-	worldTransform_ = std::make_unique<WorldTransform>();
+        this->object3dCommon_ = object3dCommon;
+        worldTransform_ = worldTransform;
 
 	//modelData = LoadobjFile("resources", "plane.obj");
 
@@ -137,11 +137,7 @@ void Object3d::Cleanup()
 		materialResource_.Reset();             
 		materialData_ = nullptr;               
 	}
-	//model_ = nullptr; // ModelManager가 관리 중이므로 해제하지 않음
-	if (worldTransform_) {
-		worldTransform_->Cleanup();   // 또는 worldTransform_->Cleanup()
-		worldTransform_.reset();     // unique_ptr 해제
-	}
+        //model_ = nullptr; // ModelManager가 관리 중이므로 해제하지 않음
 	object3dCommon_ = nullptr;
 	camera = nullptr;
 	defaultCamera = nullptr;

--- a/project/engine/3D/Object3d.h
+++ b/project/engine/3D/Object3d.h
@@ -123,7 +123,7 @@ private:
 	Camera* camera = nullptr;
 	Camera* defaultCamera = nullptr;
 
-	std::unique_ptr<WorldTransform> worldTransform_;
+        WorldTransform* worldTransform_ = nullptr;
 
 	ComPtr<ID3D12Resource> materialResource_;
 	Material* materialData_ = nullptr;


### PR DESCRIPTION
## Summary
- modify Object3d so that it stores a raw pointer to an external `WorldTransform`
- adjust Object3d initialization and cleanup logic to leave ownership of the `WorldTransform` to the caller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68493438028c8324ba63ec4a756f95c2